### PR TITLE
mumble-voip v1.5 - Refactor for Infinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Getters
 | GetPlayerCallChannel           | Returns player call channel               | int           | int            |
 ### Credits
 
-@Itokoyamato for TokoVOIP 
-@Nardah and @crunchFiveM for Testing
-@blattersturm for the grid concept
+- @Itokoyamato for TokoVOIP 
+- @Nardah and @crunchFiveM for Testing
+- @blattersturm for the grid concept

--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ A tokovoip replacement that uses fivems mumble voip
 - Calls
 - Facial animations when talking
 - Phone Speaker mode toggle
-- Hear nearby calls and radios
+- Hear nearby calls
 - HTML UI
+- Voice chat & Microphone disabled warning messages
+- 3D Proximity base audio
+- Onesync/Infinity/Beyond support
+- Grid system for voice channels
 
 ### Exports
 Setters
@@ -45,3 +49,4 @@ Getters
 
 @Itokoyamato for TokoVOIP 
 @Nardah and @crunchFiveM for Testing
+@blattersturm for the grid concept

--- a/client.lua
+++ b/client.lua
@@ -1,7 +1,7 @@
 local playerServerId = GetPlayerServerId(PlayerId())
 local unmutedPlayers = {}
 local radioTargets = {}
-local phoneTargets = {}
+local callTargets = {}
 local playerChunk = nil
 local voiceTarget = 2
 

--- a/client.lua
+++ b/client.lua
@@ -253,12 +253,12 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 		DebugMsg("Player " .. player .. " radio talking state was changed from: " .. tostring(radioActive):upper() .. " to: " .. tostring(value):upper())
 		if radioChannel > 0 then
 			if playerData.radio ~= nil then
-				if playerData.radio == radioChannel then -- Check if player is in the same radio channel as you					
-					PlayMicClick(radioChannel, value)
-
+				if playerData.radio == radioChannel then -- Check if player is in the same radio channel as you
 					if player ~= playerServerId then
 						TogglePlayerVoice(player, value)
 					end
+
+					PlayMicClick(radioChannel, value)
 				end
 			end
 		end

--- a/client.lua
+++ b/client.lua
@@ -106,6 +106,23 @@ function SetCallChannel(channel)
 	end
 end
 
+function CheckVoiceSetting(varName, msg)
+	local setting = GetConvarInt(varName, -1)
+
+	if setting == 0 then
+		SendNUIMessage({ warningId = varName, warningMsg = msg })
+
+		Citizen.CreateThread(function()
+			local varName = varName
+			while GetConvarInt(varName, -1) == 0 do
+				Citizen.Wait(1000)
+			end
+
+			SendNUIMessage({ warningId = varName })
+		end)
+	end
+end
+
 -- Events
 AddEventHandler("onClientResourceStart", function(resName) -- Initialises the script, sets up voice range, voice targets and request sync with server
 	if GetCurrentResourceName() ~= resName then
@@ -123,6 +140,9 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 	DebugMsg("Initialising")
 
 	SendNUIMessage({ speakerOption = mumbleConfig.callSpeakerEnabled })
+	
+	CheckVoiceSetting("profile_voiceEnable", "Voice chat disabled")
+	CheckVoiceSetting("profile_voiceTalkEnabled", "Microphone disabled")
 end)
 
 RegisterNetEvent("mumble:SetVoiceData") -- Used to sync players data each time something changes

--- a/client.lua
+++ b/client.lua
@@ -236,7 +236,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 	local playerData = voiceData[playerServerId]
 
 	if not playerData then
-		playerData  = {
+		playerData = {
 			mode = 2,
 			radio = 0,
 			radioActive = false,

--- a/client.lua
+++ b/client.lua
@@ -223,12 +223,29 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					DebugMsg("Player " .. player .. " was removed from radio channel " .. radioChannel)
 					radioData[radioChannel][player] = nil
 
-					if CompareChannels(playerData, player, "radio", radioChannel) then
-						TogglePlayerVoice(player, false) -- mute player on radio channel leave
+					if CompareChannels(playerData, player, "radio", radioChannel, true) then
+						if playerServerId ~= player then
+							TogglePlayerVoice(player, false) -- mute player on radio channel leave
 
-						if radioTargets[player] then
-							radioTargets[player] = nil									
-							-- Maybe clear player targets here? might cut the audio for other people on the radio until the func is complete?
+							if radioTargets[player] then
+								radioTargets[player] = nil
+							end
+						elseif playerServerId == player then
+							for id, _ in pairs(radioData[radioChannel]) do -- Mute players that aren't supposed to be unmuted
+								if id ~= playerServerId then
+									if unmutedPlayers[id] then -- Check if a player isn't muted
+										if playerData.call > 0 then -- Check if the client is in a call
+											if not CompareChannels(voiceData[id], id, "call", playerData.call, true) then -- Check if the client is in a call with the unmuted player
+												TogglePlayerVoice(id, false)
+											end
+										else
+											if unmutedPlayers[id] then
+												TogglePlayerVoice(id, false)
+											end
+										end
+									end
+								end
+							end
 						end
 					end
 				end

--- a/client.lua
+++ b/client.lua
@@ -72,20 +72,25 @@ function SetGridTargets(pos) -- Used to set the players voice targets depending 
 	end
 end
 
-function SetPlayerTargets(...)
+function SetPlayerTargets(...)	
 	local targets = { ... }
 	local targetList = ""
-
+	local addedTargets = {}
+	
 	MumbleClearVoiceTargetPlayers(voiceTarget)
 
 	for i = 1, #targets do
 		for id, _ in pairs(targets[i]) do
-			MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id)
+			if not addedTargets[id] then
+				MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id)
 
-			if targetList == "" then
-				targetList = targetList .. id
-			else
-				targetList = targetList .. ", " .. id
+				if targetList == "" then
+					targetList = targetList .. id
+				else
+					targetList = targetList .. ", " .. id
+				end
+
+				addedTargets[id] = true
 			end
 		end
 	end

--- a/client.lua
+++ b/client.lua
@@ -245,18 +245,20 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			radioData[value][player] = true -- Add player to channel
 
 			if CompareChannels(playerData, player, "radio", value) then
-				if not radioTargets[player] then
-					radioTargets[player] = true							
-					
-					if playerData.radioActive then -- Send voice to newly joined player if we are currently talking
-						MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player)
+				if playerServerId ~= player then
+					if not radioTargets[player] then
+						radioTargets[player] = true							
+						
+						if playerData.radioActive then -- Send voice to newly joined player if we are currently talking
+							MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player)
+						end
 					end
-				end
-			elseif playerServerId == player then
-				for id, _ in pairs(radioData[value]) do
-					if id ~= playerServerId then
-						if not radioTargets[id] then
-							radioTargets[id] = true
+				elseif playerServerId == player then
+					for id, _ in pairs(radioData[value]) do
+						if id ~= playerServerId then
+							if not radioTargets[id] then
+								radioTargets[id] = true
+							end
 						end
 					end
 				end
@@ -290,27 +292,29 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			DebugMsg("Player " .. player .. " was added to call: " .. value)
 			callData[value][player] = true -- Add player to call
 
-			if CompareChannels(playerData, player, "call", value) then
-				TogglePlayerVoice(player, value)
+			if CompareChannels(playerData, player, "call", value, true) then
+				if playerServerId ~= player then
+					TogglePlayerVoice(player, value)
 
-				if not callTargets[player] then
-					callTargets[player] = true
-					MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player) -- Send voice to player who just joined call
-				end
-			elseif playerServerId == player then
-				for id, _ in pairs(callData[value]) do
-					if id ~= playerServerId then
-						if not unmutedPlayers[id] then
-							TogglePlayerVoice(id, true)
-						end
-
-						if not callTargets[id] then
-							callTargets[id] = true
-							MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id) -- Send voice to call participant
+					if not callTargets[player] then
+						callTargets[player] = true
+						MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player) -- Send voice to player who just joined call
+					end
+				elseif playerServerId == player then
+					for id, _ in pairs(callData[value]) do
+						if id ~= playerServerId then
+							if not unmutedPlayers[id] then
+								TogglePlayerVoice(id, true)
+							end
+	
+							if not callTargets[id] then
+								callTargets[id] = true
+								MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id) -- Send voice to call participant
+							end
 						end
 					end
 				end
-			end			
+			end		
 		end
 	elseif key == "radioActive" and radioActive ~= value then
 		DebugMsg("Player " .. player .. " radio talking state was changed from: " .. tostring(radioActive):upper() .. " to: " .. tostring(value):upper())

--- a/client.lua
+++ b/client.lua
@@ -404,7 +404,6 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			end
 		end
 	elseif key == "speakerTargets" then
-		print("OK WE GOT A SPEAKER TARGET BOI")
 		local speakerTargetsRemoved = false
 		local speakerTargetsAdded = {}
 
@@ -454,6 +453,39 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					MumbleAddVoiceTargetPlayerByServerId(voiceTarget, speakerTargetsAdded[i])
 				end
 			end
+		end
+	elseif key == "callSpeaker" and not value then
+		if voiceData[player] ~= nil then
+			if voiceData[player].call ~= nil then
+				if voiceData[player].call > 0  then
+					if callData[voiceData[player].call] ~= nil then -- Check if the call exists
+						for id, _ in pairs(callData[voiceData[player].call]) do -- Loop through each call participant
+							if voiceData[id] ~= nil then
+								if voiceData[id].speakerTargets ~= nil then
+									local speakerTargetsRemoved = false
+
+									for targetId, _ in pairs(voiceData[id].speakerTargets) do -- Loop through each call participants speaker targets
+										if playerServerId == targetId then -- Check if the client was a target and mute the call
+											TogglePlayerVoice(id, false) -- Mute
+										end
+
+										if playerServerId == id then -- Check if the client is a paricipant in the phone call whose voice is heard through the speaker
+											if speakerTargets[targetId] then -- Stop sending voice to player
+												speakerTargets[targetId] = nil
+												speakerTargetsRemoved = true
+											end
+										end	
+									end
+
+									if speakerTargetsRemoved then
+										SetPlayerTargets(callTargets, speakerTargets, playerData.radioActive and radioTargets or nil)
+									end
+								end
+							end
+						end
+					end
+				end
+			end 
 		end
 	end
 

--- a/client.lua
+++ b/client.lua
@@ -147,10 +147,10 @@ function CheckVoiceSetting(varName, msg)
 	DebugMsg("Checking setting: " .. varName .. " = " .. setting)
 end
 
-function CompareChannels(playerData, player, type, channel)
+function CompareChannels(playerData, player, type, channel, ignoreId)
 	local match = false
 
-	if player ~= playerServerId then
+	if ignoreId and true or (player ~= playerServerId) then
 		if playerData[type] ~= nil then
 			if playerData[type] == channel then
 				match = true

--- a/client.lua
+++ b/client.lua
@@ -280,6 +280,11 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 			if CompareChannels(playerData, player, "call", value) then
 				TogglePlayerVoice(player, value)
+
+				if not callTargets[player] then
+					callTargets[player] = true
+					MumbleAddVoiceTargetPlayerByServerId(player) -- Send voice to player who just joined call
+				end
 			elseif playerServerId == player then
 				for id, _ in pairs(callData[value]) do
 					if id ~= playerServerId then

--- a/client.lua
+++ b/client.lua
@@ -294,12 +294,14 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 							MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player)
 						end
 					end
-				elseif playerServerId == player then
-					for id, _ in pairs(radioData[value]) do -- Add radio targets of existing players in channel
-						if id ~= playerServerId then
-							if not radioTargets[id] then
-								radioTargets[id] = true
-							end
+				end
+			end
+
+			if playerServerId == player then
+				for id, _ in pairs(radioData[value]) do -- Add radio targets of existing players in channel
+					if id ~= playerServerId then
+						if not radioTargets[id] then
+							radioTargets[id] = true
 						end
 					end
 				end
@@ -369,21 +371,23 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 						callTargets[player] = true
 						MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player) -- Send voice to player who just joined call
 					end
-				elseif playerServerId == player then
-					for id, _ in pairs(callData[value]) do
-						if id ~= playerServerId then
-							if not unmutedPlayers[id] then
-								TogglePlayerVoice(id, true)
-							end
-	
-							if not callTargets[id] then
-								callTargets[id] = true
-								MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id) -- Send voice to call participant
-							end
+				end
+			end
+			
+			if playerServerId == player then
+				for id, _ in pairs(callData[value]) do
+					if id ~= playerServerId then
+						if not unmutedPlayers[id] then
+							TogglePlayerVoice(id, true)
+						end
+
+						if not callTargets[id] then
+							callTargets[id] = true
+							MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id) -- Send voice to call participant
 						end
 					end
 				end
-			end		
+			end
 		end
 	elseif key == "radioActive" and radioActive ~= value then
 		DebugMsg("Player " .. player .. " radio talking state was changed from: " .. tostring(radioActive):upper() .. " to: " .. tostring(value):upper())

--- a/client.lua
+++ b/client.lua
@@ -82,7 +82,6 @@ function SetPlayerTargets(...)
 	for i = 1, #targets do
 		for id, _ in pairs(targets[i]) do
 			if not addedTargets[id] then
-				print(id, _)
 				MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id)
 
 				if targetList == "" then
@@ -216,6 +215,8 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 
 	CheckVoiceSetting("profile_voiceEnable", "Voice chat disabled")
 	CheckVoiceSetting("profile_voiceTalkEnabled", "Microphone disabled")
+
+	TriggerEvent("mumble:Initialised")
 end)
 
 RegisterNetEvent("mumble:SetVoiceData") -- Used to sync players data each time something changes

--- a/client.lua
+++ b/client.lua
@@ -82,6 +82,7 @@ function SetPlayerTargets(...)
 	for i = 1, #targets do
 		for id, _ in pairs(targets[i]) do
 			if not addedTargets[id] then
+				print(id, _)
 				MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id)
 
 				if targetList == "" then

--- a/client.lua
+++ b/client.lua
@@ -151,14 +151,12 @@ function CheckVoiceSetting(varName, msg)
 	DebugMsg("Checking setting: " .. varName .. " = " .. setting)
 end
 
-function CompareChannels(playerData, player, type, channel, ignoreId)
+function CompareChannels(playerData, player, type, channel)
 	local match = false
 
-	if ignoreId and true or (player ~= playerServerId) then
-		if playerData[type] ~= nil then
-			if playerData[type] == channel then
-				match = true
-			end
+	if playerData[type] ~= nil then
+		if playerData[type] == channel then
+			match = true
 		end
 	end
 
@@ -223,7 +221,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					DebugMsg("Player " .. player .. " was removed from radio channel " .. radioChannel)
 					radioData[radioChannel][player] = nil
 
-					if CompareChannels(playerData, player, "radio", radioChannel, true) then
+					if CompareChannels(playerData, player, "radio", radioChannel) then
 						if playerServerId ~= player then
 							TogglePlayerVoice(player, false) -- mute player on radio channel leave
 
@@ -235,7 +233,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 								if id ~= playerServerId then
 									if unmutedPlayers[id] then -- Check if a player isn't muted
 										if playerData.call > 0 then -- Check if the client is in a call
-											if not CompareChannels(voiceData[id], id, "call", playerData.call, true) then -- Check if the client is in a call with the unmuted player
+											if not CompareChannels(voiceData[id], id, "call", playerData.call) then -- Check if the client is in a call with the unmuted player
 												TogglePlayerVoice(id, false)
 											end
 										else
@@ -277,7 +275,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 						end
 					end
 				elseif playerServerId == player then
-					for id, _ in pairs(radioData[value]) do
+					for id, _ in pairs(radioData[value]) do -- Add radio targets of existing players in channel
 						if id ~= playerServerId then
 							if not radioTargets[id] then
 								radioTargets[id] = true
@@ -315,7 +313,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			DebugMsg("Player " .. player .. " was added to call: " .. value)
 			callData[value][player] = true -- Add player to call
 
-			if CompareChannels(playerData, player, "call", value, true) then
+			if CompareChannels(playerData, player, "call", value) then
 				if playerServerId ~= player then
 					TogglePlayerVoice(player, value)
 
@@ -343,8 +341,10 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 		DebugMsg("Player " .. player .. " radio talking state was changed from: " .. tostring(radioActive):upper() .. " to: " .. tostring(value):upper())
 		if radioChannel > 0 then
 			if CompareChannels(playerData, player, "radio", radioChannel) then -- Check if player is in the same radio channel as you
-				TogglePlayerVoice(player, value) -- unmute/mute player
-				PlayMicClick(radioChannel, value) -- play on/off clicks
+				if playerServerId ~= player then
+					TogglePlayerVoice(player, value) -- unmute/mute player
+					PlayMicClick(radioChannel, value) -- play on/off clicks
+				end
 			end
 		end
 	end

--- a/client.lua
+++ b/client.lua
@@ -543,6 +543,27 @@ AddEventHandler("mumble:RemoveVoiceData", function(player)
 			end
 		end
 
+		if radioTargets[player] or callTargets[player] or speakerTargets[player] then
+			local playerData = voiceData[playerServerId]
+
+			if not playerData then
+				playerData = {
+					mode = 2,
+					radio = 0,
+					radioActive = false,
+					call = 0,
+					callSpeaker = false,
+					speakerTargets = {},
+				}
+			end
+
+			radioTargets[player] = nil
+			callTargets[player] = nil
+			speakerTargets[player] = nil
+
+			SetPlayerTargets(callTargets, speakerTargets, playerData.radioActive and radioTargets or nil)
+		end
+
 		voiceData[player] = nil
 	end
 end)

--- a/client.lua
+++ b/client.lua
@@ -121,6 +121,8 @@ function CheckVoiceSetting(varName, msg)
 			SendNUIMessage({ warningId = varName })
 		end)
 	end
+
+	DebugMsg("Checking setting: " .. varName .. " = " .. setting)
 end
 
 -- Events
@@ -142,7 +144,7 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 	Citizen.Wait(1000)
 
 	SendNUIMessage({ speakerOption = mumbleConfig.callSpeakerEnabled })
-	
+
 	CheckVoiceSetting("profile_voiceEnable", "Voice chat disabled")
 	CheckVoiceSetting("profile_voiceTalkEnabled", "Microphone disabled")
 end)

--- a/client.lua
+++ b/client.lua
@@ -259,6 +259,11 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 					if CompareChannels(playerData, player, "call", callChannel) then
 						TogglePlayerVoice(player, false) -- mute player on call channel leave
+
+						if callTargets[player] then
+							callTargets[player] = nil
+							SetPlayerTargets(callTargets, playerData.radioActive and radioTargets or nil)
+						end
 					end
 				end
 			end

--- a/client.lua
+++ b/client.lua
@@ -196,11 +196,24 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 		return
 	end
 
-	MumbleClearVoiceTarget(voiceTarget) -- Reset voice target
-	MumbleSetVoiceTarget(voiceTarget)
+	DebugMsg("Initialising")
 
 	Citizen.Wait(2500)
 
+	
+	CheckVoiceSetting("profile_voiceEnable", "Voice chat disabled")
+	CheckVoiceSetting("profile_voiceTalkEnabled", "Microphone disabled")
+
+	if not MumbleIsConnected() then
+		SendNUIMessage({ warningId = "mumble_is_connected", warningMsg = "Not connected to mumble" })
+
+		while not MumbleIsConnected() do
+			Citizen.Wait(250)
+		end
+
+		SendNUIMessage({ warningId = "mumble_is_connected" })
+	end
+	
 	NetworkSetTalkerProximity(mumbleConfig.voiceModes[2][1] + 0.0)
 
 	MumbleClearVoiceTarget(voiceTarget) -- Reset voice target
@@ -209,12 +222,7 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 
 	TriggerServerEvent("mumble:Initialise")
 
-	DebugMsg("Initialising")
-
 	SendNUIMessage({ speakerOption = mumbleConfig.callSpeakerEnabled })
-
-	CheckVoiceSetting("profile_voiceEnable", "Voice chat disabled")
-	CheckVoiceSetting("profile_voiceTalkEnabled", "Microphone disabled")
 
 	TriggerEvent("mumble:Initialised")
 end)

--- a/client.lua
+++ b/client.lua
@@ -171,7 +171,7 @@ function CheckVoiceSetting(varName, msg)
 	DebugMsg("Checking setting: " .. varName .. " = " .. setting)
 end
 
-function CompareChannels(playerData, player, type, channel)
+function CompareChannels(playerData, type, channel)
 	local match = false
 
 	if playerData[type] ~= nil then
@@ -241,7 +241,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					DebugMsg("Player " .. player .. " was removed from radio channel " .. radioChannel)
 					radioData[radioChannel][player] = nil
 
-					if CompareChannels(playerData, player, "radio", radioChannel) then
+					if CompareChannels(playerData, "radio", radioChannel) then
 						if playerServerId ~= player then
 							TogglePlayerVoice(player, false) -- mute player on radio channel leave
 
@@ -253,7 +253,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 								if id ~= playerServerId then
 									if unmutedPlayers[id] then -- Check if a player isn't muted
 										if playerData.call > 0 then -- Check if the client is in a call
-											if not CompareChannels(voiceData[id], id, "call", playerData.call) then -- Check if the client is in a call with the unmuted player
+											if not CompareChannels(voiceData[id], "call", playerData.call) then -- Check if the client is in a call with the unmuted player
 												TogglePlayerVoice(id, false)
 											end
 										else
@@ -285,7 +285,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			DebugMsg("Player " .. player .. " was added to channel: " .. value)
 			radioData[value][player] = true -- Add player to channel
 
-			if CompareChannels(playerData, player, "radio", value) then
+			if CompareChannels(playerData, "radio", value) then
 				if playerServerId ~= player then
 					if not radioTargets[player] then
 						radioTargets[player] = true							
@@ -312,7 +312,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					DebugMsg("Player " .. player .. " was removed from call channel " .. callChannel)
 					callData[callChannel][player] = nil
 
-					if CompareChannels(playerData, player, "call", callChannel) then
+					if CompareChannels(playerData, "call", callChannel) then
 						if playerServerId ~= player then
 							TogglePlayerVoice(player, false) -- mute player on call channel leave
 
@@ -325,7 +325,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 								if id ~= playerServerId then
 									if unmutedPlayers[id] then -- Check if a player isn't muted
 										if playerData.radio > 0 then -- Check if the client is in a radio channel
-											if not CompareChannels(voiceData[id], id, "radio", playerData.radio) then -- Check if the client isn't in the radio channel with the unmuted player
+											if not CompareChannels(voiceData[id], "radio", playerData.radio) then -- Check if the client isn't in the radio channel with the unmuted player
 												TogglePlayerVoice(id, false)
 											else -- Client is in the same radio channel with unmuted player
 												if voiceData[id] ~= nil then
@@ -361,7 +361,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			DebugMsg("Player " .. player .. " was added to call: " .. value)
 			callData[value][player] = true -- Add player to call
 
-			if CompareChannels(playerData, player, "call", value) then
+			if CompareChannels(playerData, "call", value) then
 				if playerServerId ~= player then
 					TogglePlayerVoice(player, value)
 
@@ -388,7 +388,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 	elseif key == "radioActive" and radioActive ~= value then
 		DebugMsg("Player " .. player .. " radio talking state was changed from: " .. tostring(radioActive):upper() .. " to: " .. tostring(value):upper())
 		if radioChannel > 0 then
-			if CompareChannels(playerData, player, "radio", radioChannel) then -- Check if player is in the same radio channel as you
+			if CompareChannels(playerData, "radio", radioChannel) then -- Check if player is in the same radio channel as you
 				if playerServerId ~= player then
 					TogglePlayerVoice(player, value) -- unmute/mute player
 					PlayMicClick(radioChannel, value) -- play on/off clicks

--- a/client.lua
+++ b/client.lua
@@ -58,7 +58,7 @@ function SetPlayerTargets(...)
 
 	for i = 1, #targets do
 		for id, _ in pairs(targets[i]) do
-			MumbleAddVoiceTargetPlayerByServerId(id)
+			MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id)
 
 			if targetList == "" then
 				targetList = targetList .. id
@@ -249,7 +249,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					radioTargets[player] = true							
 					
 					if playerData.radioActive then -- Send voice to newly joined player if we are currently talking
-						MumbleAddVoiceTargetPlayerByServerId(player)
+						MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player)
 					end
 				end
 			elseif playerServerId == player then
@@ -295,7 +295,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 				if not callTargets[player] then
 					callTargets[player] = true
-					MumbleAddVoiceTargetPlayerByServerId(player) -- Send voice to player who just joined call
+					MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player) -- Send voice to player who just joined call
 				end
 			elseif playerServerId == player then
 				for id, _ in pairs(callData[value]) do
@@ -306,7 +306,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 						if not callTargets[id] then
 							callTargets[id] = true
-							MumbleAddVoiceTargetPlayerByServerId(id) -- Send voice to call participant
+							MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id) -- Send voice to call participant
 						end
 					end
 				end

--- a/client.lua
+++ b/client.lua
@@ -322,7 +322,10 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 									end
 								end
 							end
+							
+							callTargets = {} -- Remove all call targets as client has left the call
 
+							SetPlayerTargets(callTargets, playerData.radioActive and radioTargets or nil) -- Reset player targets
 						end
 					end
 				end

--- a/client.lua
+++ b/client.lua
@@ -24,7 +24,7 @@ function SetGridTargets(pos) -- Used to set the players voice targets depending 
 
 	if playerChunk ~= currentChunk then
 		local nearbyChunks = GetNearbyChunks(pos)
-		local nearybyChunksStr = "None"
+		local nearbyChunksStr = "None"
 
 		MumbleClearVoiceTargetChannels(voiceTarget)
 
@@ -32,10 +32,10 @@ function SetGridTargets(pos) -- Used to set the players voice targets depending 
 			MumbleAddVoiceTargetChannel(voiceTarget, nearbyChunks[i])
 
 			if nearbyChunks[i] ~= currentChunk then
-				if nearybyChunksStr ~= "None" then
-					nearybyChunksStr = nearybyChunksStr .. ", " .. nearbyChunks[i]
+				if nearbyChunksStr ~= "None" then
+					nearbyChunksStr = nearbyChunksStr .. ", " .. nearbyChunks[i]
 				else
-					nearybyChunksStr = nearbyChunks[i]
+					nearbyChunksStr = nearbyChunks[i]
 				end
 			end
 		end
@@ -44,7 +44,7 @@ function SetGridTargets(pos) -- Used to set the players voice targets depending 
 
 		playerChunk = currentChunk
 
-		DebugMsg("Entered Chunk: " .. currentChunk .. ", Nearby Chunks: " .. nearybyChunksStr)
+		DebugMsg("Entered Chunk: " .. currentChunk .. ", Nearby Chunks: " .. nearbyChunksStr)
 	end
 end
 

--- a/client.lua
+++ b/client.lua
@@ -715,12 +715,20 @@ Citizen.CreateThread(function()
 							local distance = #(playerPos - remotePlayerPos)
 							
 							if distance <= mumbleConfig.speakerRange then
-								nearbyPlayers[remotePlayerServerId] = true							
+								local remotePlayerData = voiceData[remotePlayerServerId]
 
-								if nearbySpeakerTargets[remotePlayerServerId] then
-									nearbySpeakerTargets[remotePlayerServerId] = nil
-								else
-									nearbyPlayerAdded = true
+								if remotePlayerData ~= nil then
+									if remotePlayerData.call ~= nil then
+										if remotePlayerData.call ~= playerData.call then
+											nearbyPlayers[remotePlayerServerId] = true
+											
+											if nearbySpeakerTargets[remotePlayerServerId] then
+												nearbySpeakerTargets[remotePlayerServerId] = nil
+											else
+												nearbyPlayerAdded = true
+											end
+										end
+									end
 								end
 							end
 						end

--- a/client.lua
+++ b/client.lua
@@ -1,6 +1,7 @@
 local playerServerId = GetPlayerServerId(PlayerId())
 local unmutedPlayers = {}
-
+local radioTargets = {}
+local phoneTargets = {}
 local playerChunk = nil
 local voiceTarget = 2
 

--- a/client.lua
+++ b/client.lua
@@ -239,6 +239,16 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			
 			DebugMsg("Player " .. player .. " was added to channel: " .. value)
 			radioData[value][player] = true -- Add player to channel
+
+			if CompareChannels(playerData, player, "radio", value) then
+				if not radioTargets[player] then
+					radioTargets[player] = true							
+					
+					if playerData.radioActive then -- Send voice to newly joined player if we are currently talking
+						MumbleAddVoiceTargetPlayerByServerId(player)
+					end
+				end
+			end
 		end
 	elseif key == "call" and callChannel ~= value then
 		if callChannel > 0 then -- Check if player was in a call channel

--- a/client.lua
+++ b/client.lua
@@ -27,11 +27,12 @@ function SetGridTargets(pos) -- Used to set the players voice targets depending 
 		local nearbyChunksStr = "None"
 
 		MumbleClearVoiceTargetChannels(voiceTarget)
-
+		MumbleAddVoiceTargetChannel(voiceTarget, currentChunk)
+		
 		for i = 1, #nearbyChunks do
-			MumbleAddVoiceTargetChannel(voiceTarget, nearbyChunks[i])
-
 			if nearbyChunks[i] ~= currentChunk then
+				MumbleAddVoiceTargetChannel(voiceTarget, nearbyChunks[i])
+
 				if nearbyChunksStr ~= "None" then
 					nearbyChunksStr = nearbyChunksStr .. ", " .. nearbyChunks[i]
 				else

--- a/client.lua
+++ b/client.lua
@@ -49,6 +49,18 @@ function SetGridTargets(pos) -- Used to set the players voice targets depending 
 	end
 end
 
+function SetPlayerTargets(...)
+	local targets = { ... }
+
+	MumbleClearVoiceTargetPlayers(voiceTarget)
+
+	for i = 1, #targets do
+		for id, _ in pairs(targets[i]) do
+			MumbleAddVoiceTargetPlayerByServerId(id)
+		end
+	end
+end
+
 function TogglePlayerVoice(serverId, value)
 	DebugMsg((value and "Unmuting" or "Muting") .. " Player " .. serverId)
 	if value then

--- a/client.lua
+++ b/client.lua
@@ -293,11 +293,36 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					callData[callChannel][player] = nil
 
 					if CompareChannels(playerData, player, "call", callChannel) then
-						TogglePlayerVoice(player, false) -- mute player on call channel leave
+						if playerServerId ~= player then
+							TogglePlayerVoice(player, false) -- mute player on call channel leave
 
-						if callTargets[player] then
-							callTargets[player] = nil
-							SetPlayerTargets(callTargets, playerData.radioActive and radioTargets or nil)
+							if callTargets[player] then
+								callTargets[player] = nil
+								SetPlayerTargets(callTargets, playerData.radioActive and radioTargets or nil)
+							end
+						elseif playerServerId == player then
+							for id, _ in pairs(callData[callChannel]) do -- Mute players that aren't supposed to be unmuted
+								if id ~= playerServerId then
+									if unmutedPlayers[id] then -- Check if a player isn't muted
+										if playerData.radio > 0 then -- Check if the client is in a radio channel
+											if not CompareChannels(voiceData[id], id, "radio", playerData.radio) then -- Check if the client isn't in the radio channel with the unmuted player
+												TogglePlayerVoice(id, false)
+											else -- Client is in the same radio channel with unmuted player
+												if voiceData[id] ~= nil then
+													if not voiceData[id].radioActive then -- Check if the unmuted player isn't talking
+														TogglePlayerVoice(id, false)
+													end
+												end
+											end
+										else
+											if unmutedPlayers[id] then
+												TogglePlayerVoice(id, false)
+											end
+										end
+									end
+								end
+							end
+
 						end
 					end
 				end

--- a/client.lua
+++ b/client.lua
@@ -176,6 +176,8 @@ function CheckVoiceSetting(varName, msg)
 	end
 
 	DebugMsg("Checking setting: " .. varName .. " = " .. setting)
+
+	return setting == 1
 end
 
 function CompareChannels(playerData, type, channel)

--- a/client.lua
+++ b/client.lua
@@ -196,6 +196,11 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 		return
 	end
 
+	MumbleClearVoiceTarget(voiceTarget) -- Reset voice target
+	MumbleSetVoiceTarget(voiceTarget)
+
+	Citizen.Wait(2500)
+
 	NetworkSetTalkerProximity(mumbleConfig.voiceModes[2][1] + 0.0)
 
 	MumbleClearVoiceTarget(voiceTarget) -- Reset voice target
@@ -205,8 +210,6 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 	TriggerServerEvent("mumble:Initialise")
 
 	DebugMsg("Initialising")
-	
-	Citizen.Wait(1000)
 
 	SendNUIMessage({ speakerOption = mumbleConfig.callSpeakerEnabled })
 
@@ -378,6 +381,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 					if not callTargets[player] then
 						callTargets[player] = true
+						print("Adding Player " .. player .. " to voice targets")
 						MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player) -- Send voice to player who just joined call
 					end
 				end
@@ -392,6 +396,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 						if not callTargets[id] then
 							callTargets[id] = true
+							print("Adding Player " .. id .. " to voice targets")
 							MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id) -- Send voice to call participant
 						end
 					end

--- a/client.lua
+++ b/client.lua
@@ -188,6 +188,16 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 	local radioActive = voiceData[player]["radioActive"]
 	local playerData = voiceData[playerServerId]
 
+	if not playerData then
+		playerData  = {
+			mode = 2,
+			radio = 0,
+			radioActive = false,
+			call = 0,
+			callSpeaker = false,
+		}
+	end
+	
 	if key == "radio" and radioChannel ~= value then -- Check if channel has changed
 		if radioChannel > 0 then -- Check if player was in a radio channel
 			if radioData[radioChannel] then  -- Remove player from radio channel

--- a/client.lua
+++ b/client.lua
@@ -225,6 +225,14 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 						TogglePlayerVoice(player, value)
 					end
 				end
+			else
+				for id, _ in pairs(callData[value]) do
+					if id ~= playerServerId then
+						if not unmutedPlayers[id] then
+							TogglePlayerVoice(id, true)
+						end
+					end
+				end
 			end		
 		end
 	elseif key == "radioActive" and radioActive ~= value then

--- a/client.lua
+++ b/client.lua
@@ -200,6 +200,9 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 
 	Citizen.Wait(2500)
 
+	if mumbleConfig.useExternalServer then
+		MumbleSetServerAddress(mumbleConfig.externalAddress, mumbleConfig.externalPort)
+	end
 	
 	CheckVoiceSetting("profile_voiceEnable", "Voice chat disabled")
 	CheckVoiceSetting("profile_voiceTalkEnabled", "Microphone disabled")

--- a/client.lua
+++ b/client.lua
@@ -246,6 +246,12 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 									end
 								end
 							end
+							
+							radioTargets = {} -- Remove all radio targets as client has left the radio channel
+
+							if playerData.radioActive then
+								SetPlayerTargets(callTargets) -- Reset active targets if for some reason if the client was talking on the radio when the client left
+							end
 						end
 					end
 				end

--- a/client.lua
+++ b/client.lua
@@ -68,7 +68,11 @@ function SetPlayerTargets(...)
 		end
 	end
 
-	DebugMsg("Sending voice to Player " .. targetList)
+	if targetList ~= "" then
+		DebugMsg("Sending voice to Player " .. targetList)
+	else
+		DebugMsg("Sending voice to Nobody")
+	end
 end
 
 function TogglePlayerVoice(serverId, value)

--- a/client.lua
+++ b/client.lua
@@ -28,7 +28,7 @@ function SetGridTargets(pos) -- Used to set the players voice targets depending 
 
 		MumbleClearVoiceTargetChannels(voiceTarget)
 		MumbleAddVoiceTargetChannel(voiceTarget, currentChunk)
-		
+
 		for i = 1, #nearbyChunks do
 			if nearbyChunks[i] ~= currentChunk then
 				MumbleAddVoiceTargetChannel(voiceTarget, nearbyChunks[i])

--- a/client.lua
+++ b/client.lua
@@ -303,14 +303,9 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 	elseif key == "radioActive" and radioActive ~= value then
 		DebugMsg("Player " .. player .. " radio talking state was changed from: " .. tostring(radioActive):upper() .. " to: " .. tostring(value):upper())
 		if radioChannel > 0 then
-			if CompareChannels(playerData, player, "radio", radioChannel, true) then -- Check if player is in the same radio channel as you
-				if player ~= playerServerId then
-					TogglePlayerVoice(player, value)
-				else
-					SetPlayerTargets(callTargets, radioTargets) -- Send voice to everyone in the radio and call
-				end
-
-				PlayMicClick(radioChannel, value)
+			if CompareChannels(playerData, player, "radio", radioChannel) then -- Check if player is in the same radio channel as you
+				TogglePlayerVoice(player, value) -- unmute/mute player
+				PlayMicClick(radioChannel, value) -- play on/off clicks
 			end
 		end
 	end
@@ -405,6 +400,7 @@ Citizen.CreateThread(function()
 					if playerRadio > 0 then
 						SetVoiceData("radioActive", true)
 						playerData.radioActive = true
+						SetPlayerTargets(callTargets, radioTargets) -- Send voice to everyone in the radio and call
 						PlayMicClick(playerRadio, true)
 						mumbleConfig.controls.radio.pressed = true
 
@@ -414,6 +410,7 @@ Citizen.CreateThread(function()
 							end
 
 							SetVoiceData("radioActive", false)
+							SetPlayerTargets(callTargets) -- Stop sending voice to everyone in the radio
 							PlayMicClick(playerRadio, false)
 							playerData.radioActive = false
 							mumbleConfig.controls.radio.pressed = false

--- a/client.lua
+++ b/client.lua
@@ -573,7 +573,7 @@ Citizen.CreateThread(function()
 		end
 
 		if IsControlJustPressed(0, mumbleConfig.controls.proximity.key) then
-			if mumbleConfig.controls.speaker.key == mumbleConfig.controls.proximity.key and not ((mumbleConfig.controls.speaker.secondary == nil) and true or IsControlPressed(0, mumbleConfig.controls.speaker.secondary)) then
+			if mumbleConfig.controls.speaker.key ~= mumbleConfig.controls.proximity.key or ((not mumbleConfig.controls.speaker.secondary == nil) and IsControlPressed(0, mumbleConfig.controls.speaker.secondary) or true) then
 				local voiceMode = playerMode
 			
 				local newMode = voiceMode + 1
@@ -622,8 +622,8 @@ Citizen.CreateThread(function()
 			end
 		end
 
-		if mumbleConfig.radioSpeakerEnabled then
-			if ((mumbleConfig.controls.speaker.secondary == nil) and true or IsControlPressed(0, mumbleConfig.controls.speaker.secondary)) then
+		if mumbleConfig.callSpeakerEnabled then
+			if ((not mumbleConfig.controls.speaker.secondary == nil) and IsControlPressed(0, mumbleConfig.controls.speaker.secondary) or true) then
 				if IsControlJustPressed(0, mumbleConfig.controls.speaker.key) then
 					if playerCall > 0 then
 						SetVoiceData("callSpeaker", not playerCallSpeaker)

--- a/client.lua
+++ b/client.lua
@@ -131,7 +131,7 @@ function SetRadioChannel(channel)
 
 						if playerData ~= nil then
 							if playerData.radioActive then
-								TogglePlayerVoice(player, true)
+								TogglePlayerVoice(id, true)
 							end
 						end
 					end

--- a/client.lua
+++ b/client.lua
@@ -52,14 +52,23 @@ end
 
 function SetPlayerTargets(...)
 	local targets = { ... }
+	local targetList = ""
 
 	MumbleClearVoiceTargetPlayers(voiceTarget)
 
 	for i = 1, #targets do
 		for id, _ in pairs(targets[i]) do
 			MumbleAddVoiceTargetPlayerByServerId(id)
+
+			if targetList == "" then
+				targetList = targetList .. id
+			else
+				targetList = targetList .. ", " .. id
+			end
 		end
 	end
+
+	DebugMsg("Sending voice to Player " .. targetList)
 end
 
 function TogglePlayerVoice(serverId, value)

--- a/client.lua
+++ b/client.lua
@@ -291,6 +291,11 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 						if not unmutedPlayers[id] then
 							TogglePlayerVoice(id, true)
 						end
+
+						if not callTargets[id] then
+							callTargets[id] = true
+							MumbleAddVoiceTargetPlayerByServerId(id) -- Send voice to call participant
+						end
 					end
 				end
 			end			

--- a/client.lua
+++ b/client.lua
@@ -70,15 +70,14 @@ function SetRadioChannel(channel)
 		SetVoiceData("radio", channel)
 
 		if radioData[channel] then -- Check if anyone is talking and unmute if so
-			for i = 1, #radioData[channel] do
-				local player = radioData[channel][i]
-				if player then
-					if player ~= playerServerId then
-						local playerData = voiceData[player]
+			for id, _ in pairs(radioData[channel]) do
+				if id ~= playerServerId then					
+					if not unmutedPlayers[id] then
+						local playerData = voiceData[id]
 
 						if playerData ~= nil then
 							if playerData.radioActive then
-								TogglePlayerVoice(player, value)
+								TogglePlayerVoice(player, true)
 							end
 						end
 					end
@@ -95,11 +94,10 @@ function SetCallChannel(channel)
 		SetVoiceData("call", channel)
 
 		if callData[channel] then -- Unmute current call participants
-			for i = 1, #callData[channel] do
-				local player = callData[channel][i]
-				if player then
-					if player ~= playerServerId then
-						TogglePlayerVoice(player, true)
+			for id, _ in pairs(callData[channel]) do
+				if id ~= playerServerId then
+					if not unmutedPlayers[id] then
+						TogglePlayerVoice(id, true)
 					end
 				end
 			end

--- a/client.lua
+++ b/client.lua
@@ -302,8 +302,8 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					if not radioTargets[player] then
 						radioTargets[player] = true							
 						
-						if playerData.radioActive then -- Send voice to newly joined player if we are currently talking
-							MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player)
+						if playerData.radioActive then
+							SetPlayerTargets(callTargets, speakerTargets, radioTargets)
 						end
 					end
 				end
@@ -381,8 +381,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 					if not callTargets[player] then
 						callTargets[player] = true
-						print("Adding Player " .. player .. " to voice targets")
-						MumbleAddVoiceTargetPlayerByServerId(voiceTarget, player) -- Send voice to player who just joined call
+						SetPlayerTargets(callTargets, speakerTargets, playerData.radioActive and radioTargets or nil)
 					end
 				end
 			end
@@ -396,8 +395,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 						if not callTargets[id] then
 							callTargets[id] = true
-							print("Adding Player " .. id .. " to voice targets")
-							MumbleAddVoiceTargetPlayerByServerId(voiceTarget, id) -- Send voice to call participant
+							SetPlayerTargets(callTargets, speakerTargets, playerData.radioActive and radioTargets or nil)
 						end
 					end
 				end
@@ -456,13 +454,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 		end
 
 		if speakerTargetsRemoved or #speakerTargetsAdded > 0 then
-			if speakerTargetsRemoved then
-				SetPlayerTargets(callTargets, speakerTargets, playerData.radioActive and radioTargets or nil)
-			else
-				for i = 1, #speakerTargetsAdded do
-					MumbleAddVoiceTargetPlayerByServerId(voiceTarget, speakerTargetsAdded[i])
-				end
-			end
+			SetPlayerTargets(callTargets, speakerTargets, playerData.radioActive and radioTargets or nil)
 		end
 	elseif key == "callSpeaker" and not value then
 		if voiceData[player] ~= nil then

--- a/client.lua
+++ b/client.lua
@@ -138,6 +138,8 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 	TriggerServerEvent("mumble:Initialise")
 
 	DebugMsg("Initialising")
+	
+	Citizen.Wait(1000)
 
 	SendNUIMessage({ speakerOption = mumbleConfig.callSpeakerEnabled })
 	

--- a/client.lua
+++ b/client.lua
@@ -49,6 +49,7 @@ function SetGridTargets(pos) -- Used to set the players voice targets depending 
 end
 
 function TogglePlayerVoice(serverId, value)
+	DebugMsg((value and "Unmuting" or "Muting") .. " Player " .. serverId)
 	if value then
 		if not unmutedPlayers[serverId] then
 			unmutedPlayers[serverId] = true

--- a/client.lua
+++ b/client.lua
@@ -255,7 +255,15 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 					if CompareChannels(playerData, "radio", radioChannel) then
 						if playerServerId ~= player then
-							TogglePlayerVoice(player, false) -- mute player on radio channel leave
+							if unmutedPlayers[player] then
+								if playerData.call > 0 then -- Check if the client is in a call
+									if not CompareChannels(voiceData[player], "call", playerData.call) then -- Check if the client is in a call with the unmuted player
+										TogglePlayerVoice(player, false)
+									end
+								else
+									TogglePlayerVoice(player, false) -- mute player on radio channel leave
+								end
+							end
 
 							if radioTargets[player] then
 								radioTargets[player] = nil
@@ -328,7 +336,15 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 					if CompareChannels(playerData, "call", callChannel) then
 						if playerServerId ~= player then
-							TogglePlayerVoice(player, false) -- mute player on call channel leave
+							if unmutedPlayers[player] then
+								if playerData.radio > 0 then -- Check if the client is in a call
+									if not CompareChannels(voiceData[player], "radio", playerData.radio) then -- Check if the client is in a call with the unmuted player
+										TogglePlayerVoice(player, false)
+									end
+								else
+									TogglePlayerVoice(player, false) -- mute player on radio channel leave
+								end
+							end
 
 							if callTargets[player] then
 								callTargets[player] = nil

--- a/client.lua
+++ b/client.lua
@@ -252,6 +252,14 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 						MumbleAddVoiceTargetPlayerByServerId(player)
 					end
 				end
+			elseif playerServerId == player then
+				for id, _ in pairs(radioData[value]) do
+					if id ~= playerServerId then
+						if not radioTargets[id] then
+							radioTargets[id] = true
+						end
+					end
+				end
 			end
 		end
 	elseif key == "call" and callChannel ~= value then

--- a/client.lua
+++ b/client.lua
@@ -147,6 +147,20 @@ function CheckVoiceSetting(varName, msg)
 	DebugMsg("Checking setting: " .. varName .. " = " .. setting)
 end
 
+function CompareChannels(playerData, player, type, channel)
+	local match = false
+
+	if player ~= playerServerId then
+		if playerData[type] ~= nil then
+			if playerData[type] == channel then
+				match = true
+			end
+		end
+	end
+
+	return match
+end
+
 -- Events
 AddEventHandler("onClientResourceStart", function(resName) -- Initialises the script, sets up voice range, voice targets and request sync with server
 	if GetCurrentResourceName() ~= resName then

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,7 @@ voiceData = {}
 radioData = {}
 callData = {}
 mumbleConfig = {
-	debug = true, -- enable debug msgs
+	debug = false, -- enable debug msgs
 	voiceModes = {
 		{2.5, "Whisper"}, -- Whisper speech distance in gta distance units
 		{8.0, "Normal"}, -- Normal speech distance in gta distance units

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,7 @@ voiceData = {}
 radioData = {}
 callData = {}
 mumbleConfig = {
-	debug = false, -- enable debug msgs
+	debug = true, -- enable debug msgs
 	voiceModes = {
 		{2.5, "Whisper"}, -- Whisper speech distance in gta distance units
 		{8.0, "Normal"}, -- Normal speech distance in gta distance units

--- a/config.lua
+++ b/config.lua
@@ -10,7 +10,6 @@ mumbleConfig = {
 	},
 	speakerRange = 1.5, -- Speaker distance in gta distance units (how close you need to be to another player to hear other players on the radio or phone)
 	callSpeakerEnabled = true, -- Allow players to hear all talking participants of a phone call if standing next to someone that is on the phone
-	radioSpeakerEnabled = true, -- Allow players to hear all talking participants in a radio if standing next to someone that has a radio
 	radioEnabled = true, -- Enable or disable using the radio
 	micClicks = true, -- Are clicks enabled or not
 	micClickOn = true, -- Is click sound on active

--- a/config.lua
+++ b/config.lua
@@ -42,6 +42,9 @@ mumbleConfig = {
 	use3dAudio = true, -- Enable 3D Audio
 	useSendingRangeOnly = true, -- Use sending range only for proximity voice (don't recommend setting this to false)
 	useNativeAudio = false, -- Use native audio (audio occlusion in interiors)
+	useExternalServer = false, -- Use an external voice server (bigger servers need this), tutorial: https://forum.cfx.re/t/how-to-host-fivems-voice-chat-mumble-in-another-server/1487449?u=frazzle
+	externalAddress = "127.0.0.1",
+	externalPort = 30120,
 }
 resourceName = GetCurrentResourceName()
 

--- a/config.lua
+++ b/config.lua
@@ -40,6 +40,8 @@ mumbleConfig = {
 	callChannelNames = { -- Add named call channels (Defaults to [channel number])
 
 	},
+	use3dAudio = true, -- Enable 3D Audio
+	useSendingRangeOnly = true, -- Use sending range only for proximity voice (don't recommend setting this to false)
 }
 resourceName = GetCurrentResourceName()
 

--- a/config.lua
+++ b/config.lua
@@ -41,6 +41,7 @@ mumbleConfig = {
 	},
 	use3dAudio = true, -- Enable 3D Audio
 	useSendingRangeOnly = true, -- Use sending range only for proximity voice (don't recommend setting this to false)
+	useNativeAudio = false, -- Use native audio (audio occlusion in interiors)
 }
 resourceName = GetCurrentResourceName()
 

--- a/grid.lua
+++ b/grid.lua
@@ -23,6 +23,10 @@ function GetChunkId(v)
 	return v.x << bitShift | v.y
 end
 
+function GetMaxChunkId()
+	return zoneRadius << bitShift
+end
+
 function GetCurrentChunk(pos)
 	local chunk = vector2(GetGridChunk(pos.x), GetGridChunk(pos.y))
 	local chunkId = GetChunkId(chunk)

--- a/grid.lua
+++ b/grid.lua
@@ -8,17 +8,19 @@ local deltas = {
 	vector2(1, 1),
 	vector2(0, 1),
 }
+local bitShift = 2
+local zoneRadius = 128
 
 function GetGridChunk(x)
-	return math.floor((x + 8192) / 128)
+	return math.floor((x + 8192) / zoneRadius)
 end
 
 function GetGridBase(x)
-	return (x * 128) - 8192
+	return (x * zoneRadius) - 8192
 end
 
 function GetChunkId(v)
-	return (v.x << 8) | v.y
+	return v.x << bitShift | v.y
 end
 
 function GetCurrentChunk(pos)

--- a/server.lua
+++ b/server.lua
@@ -30,7 +30,7 @@ AddEventHandler("mumble:Initialise", function()
 end)
 
 RegisterNetEvent("mumble:SetVoiceData")
-AddEventHandler("mumble:SetVoiceData", function(key, value)
+AddEventHandler("mumble:SetVoiceData", function(key, value, target)
 	if not voiceData[source] then
 		voiceData[source] = {
 			mode = 2,
@@ -88,8 +88,12 @@ AddEventHandler("mumble:SetVoiceData", function(key, value)
 	voiceData[source][key] = value
 
 	DebugMsg("Player " .. source .. " changed " .. key .. " to: " .. tostring(value))
-
-	TriggerClientEvent("mumble:SetVoiceData", -1, source, key, value)
+	
+	if key == "speakerTargets" then
+		TriggerClientEvent("mumble:SetVoiceData", -1, target, key, value)
+	else
+		TriggerClientEvent("mumble:SetVoiceData", -1, source, key, value)
+	end
 end)
 
 RegisterCommand("mumbleRadioChannels", function(src, args, raw)

--- a/server.lua
+++ b/server.lua
@@ -23,6 +23,7 @@ AddEventHandler("mumble:Initialise", function()
 			radioActive = false,
 			call = 0,
 			callSpeaker = false,
+			speakerTargets = {},
 		}
 	end
 
@@ -38,6 +39,7 @@ AddEventHandler("mumble:SetVoiceData", function(key, value, target)
 			radioActive = false,
 			call = 0,
 			callSpeaker = false,
+			speakerTargets = {},
 		}
 	end
 

--- a/server.lua
+++ b/server.lua
@@ -4,7 +4,7 @@ AddEventHandler("onResourceStart", function(resName) -- Initialises the script, 
 	end
 
 	-- Set voice related convars
-	SetConvarReplicated("voice_useNativeAudio", "false")
+	SetConvarReplicated("voice_useNativeAudio", mumbleConfig.useNativeAudio and "true" or "false")
 	SetConvarReplicated("voice_use2dAudio", mumbleConfig.use3dAudio and "false" or "true")
 	SetConvarReplicated("voice_use3dAudio", mumbleConfig.use3dAudio and "true" or "false")	
 	SetConvarReplicated("voice_useSendingRangeOnly", mumbleConfig.useSendingRangeOnly and "true" or "false")	

--- a/server.lua
+++ b/server.lua
@@ -122,9 +122,6 @@ end, true)
 
 AddEventHandler("playerDropped", function()
 	if voiceData[source] then
-		local radioChanged = false
-		local callChanged = false
-
 		if voiceData[source].radio > 0 then
 			if radioData[voiceData[source].radio] ~= nil then
 				radioData[voiceData[source].radio][source] = nil

--- a/server.lua
+++ b/server.lua
@@ -9,7 +9,13 @@ AddEventHandler("onResourceStart", function(resName) -- Initialises the script, 
 	SetConvarReplicated("voice_use3dAudio", mumbleConfig.use3dAudio and "true" or "false")	
 	SetConvarReplicated("voice_useSendingRangeOnly", mumbleConfig.useSendingRangeOnly and "true" or "false")	
 
-	DebugMsg("Initialised Script")
+	local maxChannel = GetMaxChunkId() << 1 -- Double the max just in case
+
+	for i = 1, maxChannel do
+		MumbleCreateChannel(i)
+	end
+
+	DebugMsg("Initialised Script, " .. maxChannel .. " channels created")
 end)
 
 RegisterNetEvent("mumble:Initialise")

--- a/server.lua
+++ b/server.lua
@@ -4,10 +4,12 @@ AddEventHandler("onResourceStart", function(resName) -- Initialises the script, 
 	end
 
 	-- Set voice related convars
-	SetConvarReplicated("voice_useNativeAudio", 0)
-	SetConvarReplicated("voice_use2dAudio", mumbleConfig.use3dAudio and 0 or 1)
-	SetConvarReplicated("voice_use3dAudio", mumbleConfig.use3dAudio and 1 or 0)	
-	SetConvarReplicated("voice_useSendingRangeOnly", mumbleConfig.useSendingRangeOnly and 1 or 0)	
+	SetConvarReplicated("voice_useNativeAudio", "false")
+	SetConvarReplicated("voice_use2dAudio", mumbleConfig.use3dAudio and "false" or "true")
+	SetConvarReplicated("voice_use3dAudio", mumbleConfig.use3dAudio and "true" or "false")	
+	SetConvarReplicated("voice_useSendingRangeOnly", mumbleConfig.useSendingRangeOnly and "true" or "false")	
+
+	DebugMsg("Initialised Script")
 end)
 
 RegisterNetEvent("mumble:Initialise")

--- a/server.lua
+++ b/server.lua
@@ -1,3 +1,15 @@
+AddEventHandler("onResourceStart", function(resName) -- Initialises the script, sets up voice related convars
+	if GetCurrentResourceName() ~= resName then
+		return
+	end
+
+	-- Set voice related convars
+	SetConvarReplicated("voice_useNativeAudio", 0)
+	SetConvarReplicated("voice_use2dAudio", mumbleConfig.use3dAudio and 0 or 1)
+	SetConvarReplicated("voice_use3dAudio", mumbleConfig.use3dAudio and 1 or 0)	
+	SetConvarReplicated("voice_useSendingRangeOnly", mumbleConfig.useSendingRangeOnly and 1 or 0)	
+end)
+
 RegisterNetEvent("mumble:Initialise")
 AddEventHandler("mumble:Initialise", function()
 	DebugMsg("Initialised player: " .. source)

--- a/ui/index.html
+++ b/ui/index.html
@@ -89,6 +89,28 @@
 						callElem.textContent = "";
 					}
 				}
+
+				if (item.warningId != null) {
+					let warningElem = document.getElementById("voip-warning");
+
+					if (item.warningMsg != null) {
+						let warningItem = document.createElement("div");
+						let warningItemTitle = document.createElement("span");
+						let warningItemContent = document.createElement("span");
+
+						warningItem.id = item.warningId;
+						warningItemTitle.textContent = "[Warning] ";
+						warningItemTitle.className = "talking";
+						warningItemContent.textContent = item.warningMsg;
+
+						warningItem.appendChild(warningItemTitle);
+						warningItem.appendChild(warningItemContent);
+						warningElem.appendChild(warningItem);
+					} else {
+						let warningItem = document.getElementById(item.warningId);
+						warningElem.removeChild(warningItem);
+					}
+				}
 			});
 		</script>
 	</head>
@@ -102,6 +124,7 @@
 			<div>[Mumble] <span id="voip-mode"></span></div>
 			<div id="voip-radio"></div>
 			<div id="voip-call"></div>
+			<div id="voip-warning"></div>
 		</div>
 	</body>
 </html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -55,7 +55,7 @@
 				if (item.mode) {					
 					let modeElem = document.getElementById("voip-mode");
 
-					modeElem.innerHTML = item.mode + (item.radioActive ? " on radio" : "");
+					modeElem.textContent = item.mode + (item.radioActive ? " on radio" : "");
 
 					if (item.talking != null) {
 						if (item.talking) {
@@ -70,9 +70,9 @@
 					let radioElem = document.getElementById("voip-radio");
 
 					if (item.radio > 0 || isNaN(item.radio)) {
-						radioElem.innerHTML = "[Radio] " + item.radio + (!isNaN(item.radio) ? " MHz" : "");					
+						radioElem.textContent = "[Radio] " + item.radio + (!isNaN(item.radio) ? " MHz" : "");					
 					} else {
-						radioElem.innerHTML = "";
+						radioElem.textContent = "";
 					}
 				}
 
@@ -81,12 +81,12 @@
 					
 					if (item.call > 0) {
 						if (speakerEnabled) {
-							callElem.innerHTML = "[Call] [" + (item.speaker ? "🔊" : "🔈") + "] " + item.call;
+							callElem.textContent = "[Call] [" + (item.speaker ? "🔊" : "🔈") + "] " + item.call;
 						} else {
-							callElem.innerHTML = "[Call] " + item.call;
+							callElem.textContent = "[Call] " + item.call;
 						}
 					} else {
-						callElem.innerHTML = "";
+						callElem.textContent = "";
 					}
 				}
 			});


### PR DESCRIPTION
- Use voice targets for handling who players broadcast to (no more resource warnings)
- Implement grid system for splitting up players based on location
- Completely rework hearing nearby calls
- Onesync/Infinity/Beyond support #8
- Functional 3D Proximity based audio
- Add warning messages that show if voice chat or microphone is disabled
- Handle voice convars in the script (no more: `set voice_sendingRangeOnly true` in `server.cfg`)
- Cleanup repetitive checks
- Fix invalid playerData #20
- use `textContent` instead of `innerHTML` (prevent any possible XSS exploits)
- Add `GetPlayerRadioChannel` and `GetPlayerCallChannel` export #13
- Add support for using external mumble server (untested)
- Only init after client has successfully connected to mumble server