### PR TITLE
some fixes, radio list feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ A tokovoip replacement that uses fivems mumble voip
 - Grid system for voice channels
 
 ### Exports
-Setters
+
+#### Client
+
+##### Setters
  
 | Export              | Description               | Parameter(s) |
 |---------------------|---------------------------|--------------|
@@ -35,7 +38,7 @@ Supported TokoVOIP Exports
 | addPlayerToCall       | Set call channel         | int          |
 | removePlayerFromCall  | Remove player from call  |              |
 
-Getters
+##### Getters
 
 | Export                         | Description                               | Parameter(s)  | Return type    |
 |--------------------------------|-------------------------------------------|---------------|----------------|
@@ -45,6 +48,15 @@ Getters
 | GetPlayersInPlayerRadioChannel | Returns players in a player radio channel | int           | table or false |
 | GetPlayerRadioChannel          | Returns player radio channel              | int           | int            |
 | GetPlayerCallChannel           | Returns player call channel               | int           | int            |
+
+#### Server
+
+##### Setters
+
+| Export               | Description                          | Parameter(s) |
+|----------------------|--------------------------------------|--------------|
+| SetPlayerRadioName   | Set player name on radio list        | int, string  |
+
 ### Credits
 
 - @Itokoyamato for TokoVOIP 

--- a/client.lua
+++ b/client.lua
@@ -42,6 +42,7 @@ function SetGridTargets(pos, reset) -- Used to set the players voice targets dep
 			call = 0,
 			callSpeaker = false,
 			speakerTargets = {},
+			radioName = GetRandomPhoneticLetter() + "-" + playerServerId
 		}
 	end
 
@@ -324,6 +325,7 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 		call = 0,
 		callSpeaker = false,
 		speakerTargets = {},
+		radioName = GetRandomPhoneticLetter() + "-" + playerServerId
 	}
 
 	SetGridTargets(GetEntityCoords(PlayerPedId()), true) -- Add voice targets
@@ -363,6 +365,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			call = 0,
 			callSpeaker = false,
 			speakerTargets = {},
+			radioName = GetRandomPhoneticLetter() + "-" + playerServerId
 		}
 	end
 
@@ -705,6 +708,7 @@ AddEventHandler("mumble:RemoveVoiceData", function(player)
 					call = 0,
 					callSpeaker = false,
 					speakerTargets = {},
+					radioName = GetRandomPhoneticLetter() + "-" + playerServerId
 				}
 			end
 

--- a/client.lua
+++ b/client.lua
@@ -547,7 +547,20 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 		if radioChannel > 0 then
 			if CompareChannels(playerData, "radio", radioChannel) then -- Check if player is in the same radio channel as you
 				if playerServerId ~= player then
-					TogglePlayerVoice(player, value) -- unmute/mute player
+					if value then
+						TogglePlayerVoice(player, true) -- unmute player
+					else
+						if not vehicleTargets[player] then -- Mute if player is not in client vehicle
+							if playerData.call > 0 then -- Check if the client is in a call
+								if not CompareChannels(voiceData[player], "call", playerData.call) then -- Check if the client is in a call with the unmuted player
+									TogglePlayerVoice(player, false)
+								end
+							else
+								TogglePlayerVoice(player, false) -- mute player on radio channel leave
+							end
+						end
+					end
+
 					PlayMicClick(radioChannel, value) -- play on/off clicks
 				end
 			end

--- a/client.lua
+++ b/client.lua
@@ -499,9 +499,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 													end
 												end
 											else
-												if unmutedPlayers[id] then
-													TogglePlayerVoice(id, false)
-												end
+												TogglePlayerVoice(id, false)
 											end
 										end
 									end

--- a/client.lua
+++ b/client.lua
@@ -459,9 +459,17 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 						if playerServerId ~= player then
 							if unmutedPlayers[player] then
 								if not vehicleTargets[player] then -- Mute if player is not in client vehicle
-									if playerData.radio > 0 then -- Check if the client is in a call
-										if not CompareChannels(voiceData[player], "radio", playerData.radio) then -- Check if the client is in a call with the unmuted player
+									if playerData.radio > 0 then -- Check if the client is on the radio
+										if not CompareChannels(voiceData[player], "radio", playerData.radio) then -- Check if the client is in a radio channel with the unmuted player
 											TogglePlayerVoice(player, false)
+										else
+											if voiceData[player] ~= nil then
+												if not voiceData[player].radioActive then -- Check if the unmuted player isn't talking
+													TogglePlayerVoice(player, false)
+												end
+											else
+												TogglePlayerVoice(player, false)
+											end
 										end
 									else
 										TogglePlayerVoice(player, false) -- mute player on radio channel leave
@@ -486,6 +494,8 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 														if not voiceData[id].radioActive then -- Check if the unmuted player isn't talking
 															TogglePlayerVoice(id, false)
 														end
+													else
+														TogglePlayerVoice(id, false)
 													end
 												end
 											else

--- a/client.lua
+++ b/client.lua
@@ -129,17 +129,24 @@ function SetPlayerTargets(...)
 end
 
 function TogglePlayerVoice(serverId, value)
-	DebugMsg((value and "Unmuting" or "Muting") .. " Player " .. serverId)
+	local msg = false
+
 	if value then
 		if not unmutedPlayers[serverId] then
 			unmutedPlayers[serverId] = true
 			MumbleSetVolumeOverrideByServerId(serverId, 1.0)
+			msg = true
 		end
 	else
 		if unmutedPlayers[serverId] then
 			unmutedPlayers[serverId] = nil
-			MumbleSetVolumeOverrideByServerId(serverId, -1.0)			
+			MumbleSetVolumeOverrideByServerId(serverId, -1.0)
+			msg = true	
 		end		
+	end
+
+	if msg then
+		DebugMsg((value and "Unmuting" or "Muting") .. " Player " .. serverId)
 	end
 end
 

--- a/client.lua
+++ b/client.lua
@@ -464,7 +464,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 							if mumbleConfig.showRadioList then
 								if voiceData[id] ~= nil then
 									if voiceData[id].radioName ~= nil then
-										SendNUIMessage({ radioId = id, radioName = voiceData[player].radioName }) -- Add player to radio list
+										SendNUIMessage({ radioId = id, radioName = voiceData[id].radioName }) -- Add player to radio list
 									end
 								end								
 							end

--- a/client.lua
+++ b/client.lua
@@ -393,6 +393,10 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 
 							if radioTargets[player] then
 								radioTargets[player] = nil
+
+								if mumbleConfig.showRadioList then
+									SendNUIMessage({ radioId = player }) -- Remove player from radio list
+								end
 							end
 						elseif playerServerId == player then
 							for id, _ in pairs(radioData[radioChannel]) do -- Mute players that aren't supposed to be unmuted
@@ -412,6 +416,10 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 							end
 							
 							radioTargets = {} -- Remove all radio targets as client has left the radio channel
+
+							if mumbleConfig.showRadioList then
+								SendNUIMessage({ clearRadioList = true }) -- Clear radio list
+							end
 
 							if playerData.radioActive then
 								SetPlayerTargets(callTargets, speakerTargets, vehicleTargets) -- Reset active targets if for some reason if the client was talking on the radio when the client left
@@ -436,6 +444,10 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					if not radioTargets[player] then
 						radioTargets[player] = true							
 						
+						if mumbleConfig.showRadioList then
+							SendNUIMessage({ radioId = player, radioName = voiceData[player].radioName }) -- Add player to radio list
+						end
+
 						if playerData.radioActive then
 							SetPlayerTargets(callTargets, speakerTargets, vehicleTargets, radioTargets)
 						end
@@ -448,6 +460,14 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					if id ~= playerServerId then
 						if not radioTargets[id] then
 							radioTargets[id] = true
+
+							if mumbleConfig.showRadioList then
+								if voiceData[id] ~= nil then
+									if voiceData[id].radioName ~= nil then
+										SendNUIMessage({ radioId = id, radioName = voiceData[player].radioName }) -- Add player to radio list
+									end
+								end								
+							end
 						end
 					end
 				end
@@ -575,6 +595,10 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 					end
 
 					PlayMicClick(radioChannel, value) -- play on/off clicks
+
+					if mumbleConfig.showRadioList then
+						SendNUIMessage({ radioId = player, radioTalking = value }) -- Set player talking in radio list
+					end
 				end
 			end
 		end

--- a/client.lua
+++ b/client.lua
@@ -42,7 +42,7 @@ function SetGridTargets(pos, reset) -- Used to set the players voice targets dep
 			call = 0,
 			callSpeaker = false,
 			speakerTargets = {},
-			radioName = GetRandomPhoneticLetter() + "-" + playerServerId
+			radioName = GetRandomPhoneticLetter() .. "-" .. playerServerId
 		}
 	end
 
@@ -325,7 +325,7 @@ AddEventHandler("onClientResourceStart", function(resName) -- Initialises the sc
 		call = 0,
 		callSpeaker = false,
 		speakerTargets = {},
-		radioName = GetRandomPhoneticLetter() + "-" + playerServerId
+		radioName = GetRandomPhoneticLetter() .. "-" .. playerServerId
 	}
 
 	SetGridTargets(GetEntityCoords(PlayerPedId()), true) -- Add voice targets
@@ -349,7 +349,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			call = 0,
 			callSpeaker = false,
 			speakerTargets = {},
-			radioName = GetRandomPhoneticLetter() + "-" + player
+			radioName = GetRandomPhoneticLetter() .. "-" .. player
 		}
 	end
 
@@ -366,7 +366,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			call = 0,
 			callSpeaker = false,
 			speakerTargets = {},
-			radioName = GetRandomPhoneticLetter() + "-" + playerServerId
+			radioName = GetRandomPhoneticLetter() .. "-" .. playerServerId
 		}
 	end
 
@@ -733,7 +733,7 @@ AddEventHandler("mumble:RemoveVoiceData", function(player)
 					call = 0,
 					callSpeaker = false,
 					speakerTargets = {},
-					radioName = GetRandomPhoneticLetter() + "-" + playerServerId
+					radioName = GetRandomPhoneticLetter() .. "-" .. playerServerId
 				}
 			end
 

--- a/client.lua
+++ b/client.lua
@@ -1031,7 +1031,7 @@ Citizen.CreateThread(function()
 
 						if newPassengers or removedPassengers then
 							for id, exists in pairs(targets) do
-								if exists then							
+								if exists then
 									TogglePlayerVoice(id, true)
 								end
 							end

--- a/client.lua
+++ b/client.lua
@@ -246,19 +246,32 @@ function MuteVehiclePassengers(playerData)
 	for id, exists in pairs(vehicleTargets) do
 		if exists then
 			changed = true
-
-			if playerData.radio > 0 or playerData.call > 0 then -- Only mute player if they are not in call or radio channel with client
-				local remotePlayerData = voiceData[id]				
+			if playerData.radio > 0 and playerData.call > 0 then -- Only mute player if they are not in call or radio channel with client
+				local remotePlayerData = voiceData[id]
 				if remotePlayerData ~= nil then
 					if playerData.radio == remotePlayerData.radio then
-						if not remotePlayerData.radioActive then
+						if not remotePlayerData.radioActive and playerData.call ~= remotePlayerData.call then
 							TogglePlayerVoice(id, false)
 						end
 					elseif playerData.call ~= remotePlayerData.call then
 						TogglePlayerVoice(id, false)
 					end
-				else
-					TogglePlayerVoice(id, false)
+				end
+			elseif playerData.call > 0 then
+				local remotePlayerData = voiceData[id]
+				if remotePlayerData ~= nil then
+					if playerData.call ~= remotePlayerData.call then
+						TogglePlayerVoice(id, false)
+					end
+				end
+			elseif playerData.radio > 0 then
+				local remotePlayerData = voiceData[id]
+				if remotePlayerData ~= nil then
+					if playerData.radio == remotePlayerData.radio then
+						if not remotePlayerData.radioActive then
+							TogglePlayerVoice(id, false)
+						end
+					end
 				end
 			else
 				TogglePlayerVoice(id, false)

--- a/client.lua
+++ b/client.lua
@@ -349,6 +349,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			call = 0,
 			callSpeaker = false,
 			speakerTargets = {},
+			radioName = GetRandomPhoneticLetter() + "-" + player
 		}
 	end
 

--- a/client.lua
+++ b/client.lua
@@ -456,6 +456,8 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			end
 
 			if playerServerId == player then
+				SendNUIMessage({ radioId = playerServerId, radioName = playerData.radioName, self = true }) -- Add client to radio list
+
 				for id, _ in pairs(radioData[value]) do -- Add radio targets of existing players in channel
 					if id ~= playerServerId then
 						if not radioTargets[id] then
@@ -808,6 +810,9 @@ Citizen.CreateThread(function()
 							playerData.radioActive = true
 							SetPlayerTargets(callTargets, speakerTargets, vehicleTargets, radioTargets) -- Send voice to everyone in the radio and call
 							PlayMicClick(playerData.radio, true)
+							if mumbleConfig.showRadioList then
+								SendNUIMessage({ radioId = playerServerId, radioTalking = true }) -- Set client talking in radio list
+							end
 							mumbleConfig.controls.radio.pressed = true
 
 							Citizen.CreateThread(function()
@@ -818,6 +823,9 @@ Citizen.CreateThread(function()
 								SetVoiceData("radioActive", false)
 								SetPlayerTargets(callTargets, speakerTargets, vehicleTargets) -- Stop sending voice to everyone in the radio
 								PlayMicClick(playerData.radio, false)
+								if mumbleConfig.showRadioList then
+									SendNUIMessage({ radioId = playerServerId, radioTalking = false }) -- Set client talking in radio list
+								end
 								playerData.radioActive = false
 								mumbleConfig.controls.radio.pressed = false
 							end)

--- a/client.lua
+++ b/client.lua
@@ -602,7 +602,7 @@ AddEventHandler("mumble:SetVoiceData", function(player, key, value)
 			if voiceData[player][key] ~= nil then
 				for id, _ in pairs(voiceData[player][key]) do
 					if playerServerId == id then -- Check if the client has been removed from a nearby call
-						if not vehicleTargets[id] then -- Mute if player is not in client vehicle
+						if not vehicleTargets[player] then -- Mute if player is not in client vehicle
 							TogglePlayerVoice(player, false) -- Mute
 						end
 					end

--- a/client.lua
+++ b/client.lua
@@ -41,6 +41,7 @@ function SetGridTargets(pos, reset) -- Used to set the players voice targets dep
 			radioActive = false,
 			call = 0,
 			callSpeaker = false,
+			speakerTargets = {},
 		}
 	end
 
@@ -901,6 +902,7 @@ Citizen.CreateThread(function()
 						radioActive = false,
 						call = 0,
 						callSpeaker = false,
+						speakerTargets = {},
 					}
 				end
 				

--- a/config.lua
+++ b/config.lua
@@ -128,6 +128,12 @@ else
 	exports("SetCallChannelName", SetCallChannelName)
 end
 
+function GetRandomPhoneticLetter()
+	math.randomseed(GetGameTimer())
+
+	return phoneticAlphabet[math.random(1, #phoneticAlphabet)]
+end
+
 function GetPlayersInRadioChannel(channel)
 	local channel = tonumber(channel)
 	local players = false

--- a/config.lua
+++ b/config.lua
@@ -48,6 +48,34 @@ mumbleConfig = {
 	use2dAudioInVehicles = true, -- Workaround for hearing vehicle passengers at high speeds
 }
 resourceName = GetCurrentResourceName()
+phoneticAlphabet = {
+	"Alpha",
+	"Bravo",
+	"Charlie",
+	"Delta",
+	"Echo",
+	"Foxtrot",
+	"Golf",
+	"Hotel",
+	"India",
+	"Juliet",
+	"Kilo",
+	"Lima",
+	"Mike",
+	"November",
+	"Oscar",
+	"Papa",
+	"Quebec",
+	"Romeo",
+	"Sierra",
+	"Tango",
+	"Uniform",
+	"Victor",
+	"Whisky",
+	"XRay",
+	"Yankee",
+	"Zulu",
+}
 
 if IsDuplicityVersion() then
 	function DebugMsg(msg)

--- a/config.lua
+++ b/config.lua
@@ -46,6 +46,7 @@ mumbleConfig = {
 	externalAddress = "127.0.0.1",
 	externalPort = 30120,
 	use2dAudioInVehicles = true, -- Workaround for hearing vehicle passengers at high speeds
+	showRadioList = false, -- Optional feature to show a list of players in a radio channel, to be used with server export `SetPlayerRadioName`
 }
 resourceName = GetCurrentResourceName()
 phoneticAlphabet = {

--- a/server.lua
+++ b/server.lua
@@ -30,6 +30,7 @@ AddEventHandler("mumble:Initialise", function()
 			call = 0,
 			callSpeaker = false,
 			speakerTargets = {},
+			radioName = GetRandomPhoneticLetter() + "-" + source,
 		}
 	end
 
@@ -46,6 +47,7 @@ AddEventHandler("mumble:SetVoiceData", function(key, value, target)
 			call = 0,
 			callSpeaker = false,
 			speakerTargets = {},
+			radioName = GetRandomPhoneticLetter() + "-" + source,
 		}
 	end
 
@@ -139,3 +141,13 @@ AddEventHandler("playerDropped", function()
 		TriggerClientEvent("mumble:RemoveVoiceData", -1, source)
 	end
 end)
+
+function SetPlayerRadioName(serverId, name)
+	if voiceData[serverId] then
+		local value = name or (GetRandomPhoneticLetter() + "-" + serverId)
+		voiceData[serverId].radioName = value
+		TriggerClientEvent("mumble:SetVoiceData", -1, serverId, "radioName", value)
+	end
+end
+
+exports("SetPlayerRadioName", SetPlayerRadioName)

--- a/server.lua
+++ b/server.lua
@@ -30,7 +30,7 @@ AddEventHandler("mumble:Initialise", function()
 			call = 0,
 			callSpeaker = false,
 			speakerTargets = {},
-			radioName = GetRandomPhoneticLetter() + "-" + source,
+			radioName = GetRandomPhoneticLetter() .. "-" .. source,
 		}
 	end
 
@@ -47,7 +47,7 @@ AddEventHandler("mumble:SetVoiceData", function(key, value, target)
 			call = 0,
 			callSpeaker = false,
 			speakerTargets = {},
-			radioName = GetRandomPhoneticLetter() + "-" + source,
+			radioName = GetRandomPhoneticLetter() .. "-" .. source,
 		}
 	end
 
@@ -144,7 +144,7 @@ end)
 
 function SetPlayerRadioName(serverId, name)
 	if voiceData[serverId] then
-		local value = name or (GetRandomPhoneticLetter() + "-" + serverId)
+		local value = name or (GetRandomPhoneticLetter() .. "-" .. serverId)
 		voiceData[serverId].radioName = value
 		TriggerClientEvent("mumble:SetVoiceData", -1, serverId, "radioName", value)
 	end

--- a/ui/index.html
+++ b/ui/index.html
@@ -34,6 +34,19 @@
 				font-size: 0.5vw;
 				opacity: 0.8;
 			}
+
+			.radio-list-container {
+				position: absolute;
+				top: 1%;
+				right: 0%;
+				text-align: right;
+				padding: 5px;
+				font-family: sans-serif;
+				font-weight: bold;
+				color: rgb(1, 176, 240);
+				font-size: 0.5vw;
+				text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+			}
 		</style>
 		<script type="text/javascript">
 			let speakerEnabled = true;
@@ -151,11 +164,10 @@
 		<audio id="audio_off" src="mic_click_off.ogg"></audio>
 
 		<div class="watermark">mumble-voip by Frazzle.</div>
-		
+		<div class="radio-list-container" id="voip-radio-list"></div>
 		<div class="info-container">
 			<div>[Mumble] <span id="voip-mode">Initialising</span></div>
 			<div id="voip-radio"></div>
-			<div id="voip-radio-list"></div>
 			<div id="voip-call"></div>
 			<div id="voip-warning"></div>
 		</div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,7 +7,7 @@
 			.info-container {
 				position: absolute;
 				bottom: 0%;
-				right: 0%;
+				right: 1.5%;
 				text-align: right;
 				padding: 5px;
 				font-family: sans-serif;

--- a/ui/index.html
+++ b/ui/index.html
@@ -81,7 +81,7 @@
 					
 					if (item.call > 0) {
 						if (speakerEnabled) {
-							callElem.textContent = "[Call] [" + (item.speaker ? "🔊" : "🔈") + "] " + item.call;
+							callElem.textContent = "[Call] [" + (item.speaker ? "\uD83D\uDD0A" : "\uD83D\uDD08") + "] " + item.call;
 						} else {
 							callElem.textContent = "[Call] " + item.call;
 						}

--- a/ui/index.html
+++ b/ui/index.html
@@ -121,6 +121,9 @@
 						listItem.id = "voip-radio-list-item-" + item.radioId;
 						listItem.textContent = item.radioName;
 
+						if (item.self) 
+							listItem.textContent = "\uD83D\uDD38" + listItem.textContent;
+
 						radioListElem.appendChild(listItem);
 					} else if (item.radioTalking != null) {
 						let listItem = document.getElementById("voip-radio-list-item-" + item.radioId)

--- a/ui/index.html
+++ b/ui/index.html
@@ -128,6 +128,16 @@
 				if (item.radioId != null) {
 					let radioListElem = document.getElementById("voip-radio-list");
 
+					if (!radioListElem.firstChild) { //add radio list header
+						let listHeader = document.createElement("div");
+
+						listHeader.id = "voip-radio-list-header";
+						listHeader.textContent = "\uD83D\uDCE1Radio List";
+						listHeader.style.textDecorationLine = "underline";
+
+						radioListElem.appendChild(listHeader);
+					}
+
 					if (item.radioName != null) {
 						let listItem = document.createElement("div");
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -135,6 +135,14 @@
 						radioListElem.removeChild(listItem);
 					}
 				}
+
+				if (item.clearRadioList) {
+					let radioListElem = document.getElementById("voip-radio-list");
+
+					while (radioListElem.firstChild) {
+						radioListElem.removeChild(radioListElem.firstChild);
+					}
+				}
 			});
 		</script>
 	</head>

--- a/ui/index.html
+++ b/ui/index.html
@@ -111,6 +111,30 @@
 						warningElem.removeChild(warningItem);
 					}
 				}
+
+				if (item.radioId != null) {
+					let radioListElem = document.getElementById("voip-radio-list");
+
+					if (item.radioName != null) {
+						let listItem = document.createElement("div");
+
+						listItem.id = "voip-radio-list-item-" + item.radioId;
+						listItem.textContent = item.radioName;
+
+						radioListElem.appendChild(listItem);
+					} else if (item.radioTalking != null) {
+						let listItem = document.getElementById("voip-radio-list-item-" + item.radioId)
+						
+						if (item.radioTalking) {
+							listItem.className = "talking"
+						} else {
+							listItem.className = ""
+						}
+					} else {
+						let listItem = document.getElementById("voip-radio-list-item-" + item.radioId)
+						radioListElem.removeChild(listItem);
+					}
+				}
 			});
 		</script>
 	</head>
@@ -123,6 +147,7 @@
 		<div class="info-container">
 			<div>[Mumble] <span id="voip-mode">Initialising</span></div>
 			<div id="voip-radio"></div>
+			<div id="voip-radio-list"></div>
 			<div id="voip-call"></div>
 			<div id="voip-warning"></div>
 		</div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -142,7 +142,7 @@
 						let listItem = document.createElement("div");
 
 						listItem.id = "voip-radio-list-item-" + item.radioId;
-						listItem.textContent = (item.self ? "\uD83D\uDD38" : "\uD83D\uDD39") + item.radioName;
+						listItem.textContent = item.radioName + (item.self ? "\uD83D\uDD38" : "\uD83D\uDD39");
 
 						radioListElem.appendChild(listItem);
 					} else if (item.radioTalking != null) {

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,7 +7,7 @@
 			.info-container {
 				position: absolute;
 				bottom: 0%;
-				right: 1.5%;
+				right: 0%;
 				text-align: right;
 				padding: 5px;
 				font-family: sans-serif;

--- a/ui/index.html
+++ b/ui/index.html
@@ -119,10 +119,7 @@
 						let listItem = document.createElement("div");
 
 						listItem.id = "voip-radio-list-item-" + item.radioId;
-						listItem.textContent = item.radioName;
-
-						if (item.self) 
-							listItem.textContent = "\uD83D\uDD38" + listItem.textContent;
+						listItem.textContent = (item.self ? "\uD83D\uDD38" : "") + item.radioName;
 
 						radioListElem.appendChild(listItem);
 					} else if (item.radioTalking != null) {

--- a/ui/index.html
+++ b/ui/index.html
@@ -119,7 +119,7 @@
 						let listItem = document.createElement("div");
 
 						listItem.id = "voip-radio-list-item-" + item.radioId;
-						listItem.textContent = (item.self ? "\uD83D\uDD38" : "") + item.radioName;
+						listItem.textContent = (item.self ? "\uD83D\uDD38" : "\uD83D\uDD39") + item.radioName;
 
 						radioListElem.appendChild(listItem);
 					} else if (item.radioTalking != null) {

--- a/ui/index.html
+++ b/ui/index.html
@@ -121,7 +121,7 @@
 		<div class="watermark">mumble-voip by Frazzle.</div>
 		
 		<div class="info-container">
-			<div>[Mumble] <span id="voip-mode"></span></div>
+			<div>[Mumble] <span id="voip-mode">Initialising</span></div>
 			<div id="voip-radio"></div>
 			<div id="voip-call"></div>
 			<div id="voip-warning"></div>


### PR DESCRIPTION
- add initialising msg to ui
- add a "discord overlay" list for radios #52
- add `showRadioList` config option
- add `SetPlayerRadioName(serverId, name)` server export
- fix muting the wrong player in speaker targets check
- fix missing `speakerTargets` tables from `playerData`
- fix `radioActive` event not having mute checks
- fix missing mute check on call leave
- improve passenger mute checks

![Radio List Image](https://i.imgur.com/0lqwT0C.png)