### PR TITLE
tweak: don't send mumble:SetVoiceData to all clients if mode

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -101,7 +101,7 @@ AddEventHandler("mumble:SetVoiceData", function(key, value, target)
 	
 	if key == "speakerTargets" then
 		TriggerClientEvent("mumble:SetVoiceData", -1, target, key, value)
-	else
+	elseif key ~= "mode" then
 		TriggerClientEvent("mumble:SetVoiceData", -1, source, key, value)
 	end
 end)


### PR DESCRIPTION
mode/voice proximity doesn't need to be synced to all players, it causes a lot of event spam at high player counts.